### PR TITLE
Update template_tags.php w/ time classes

### DIFF
--- a/public/template_tags.php
+++ b/public/template_tags.php
@@ -487,8 +487,8 @@ if ( ! function_exists( 'espresso_list_of_event_dates' )) {
 					$datetime_name = $datetime->name();
 					$html .= ! empty( $datetime_name ) ? '<strong>' . $datetime_name . '</strong>' : '';
 					$html .= ! empty( $datetime_name )  && $add_breaks ? '<br />' : '';
-					$html .= '<span class="dashicons dashicons-calendar"></span>' . $datetime->date_range( $date_format ) . '<br/>';
-					$html .= '<span class="dashicons dashicons-clock"></span>' . $datetime->time_range( $time_format );
+					$html .= '<span class="dashicons dashicons-calendar"></span><span class="ee-event-datetimes-li-daterange">' . $datetime->date_range( $date_format ) . '</span><br/>';
+					$html .= '<span class="dashicons dashicons-clock"></span><span class="ee-event-datetimes-li-timerange">' . $datetime->time_range( $time_format ) . '</span>';
 					$datetime_description = $datetime->description();
 					$html .= ! empty( $datetime_description )  && $add_breaks ? '<br />' : '';
 					$html .= ! empty( $datetime_description ) ? ' - ' . $datetime_description : '';


### PR DESCRIPTION
Add spans and classes to the time and date displays in the UL LI date and time structure.

Problem:
The dates and times listed in the UL, LI structure are plain text, without even a span or class to identify them.

For example, see the screenshot from this site:
http://www.skypeug.com/events/baltimore-fall-2016/

![image](https://cloud.githubusercontent.com/assets/2528599/20760833/0c04cf6e-b6ef-11e6-91f8-052ca6ac1e02.png)

Solution:
I am simply proposing to wrap those dates in a span with a class, so they can be accessed properly.  We had to made this edit manually on our site because we need to access those dates in javascript.